### PR TITLE
Buildall script

### DIFF
--- a/dist/build-syscall-replayer.sh
+++ b/dist/build-syscall-replayer.sh
@@ -122,16 +122,6 @@ if [[ "${#missingPrograms[@]}" -gt 0 ]]; then
     fi
 fi
 
-# # TODO: Either check the system for these libraries or trust the user
-# # to install them before running the script
-# if [[ "${install}" == true ]]; then
-    
-#     # Installing packages
-#     runcmd sudo apt-get install -y libboost-dev libboost-thread-dev \
-#         libboost-program-options-dev build-essential libxml2-dev libz-dev \
-#         libaio-dev libtool
-# fi
-
 #################
 # Build process #
 #################


### PR DESCRIPTION
This script creates a build directory and clones all necessary git repositories to build and install
- Lintel
- DataSeries
- tcmalloc (part of gperftools)
- tbb
- fsl-strace
- syscall-replayer

The script can install these files under `/usr/local` or in the current working directory under `syscall_replayer_release`