### PR TITLE
Update names and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ fsl-strace - an strace fork compatible with DataSeries
 
 fsl-strace extends strace with support for [DataSeries](https://github.com/dataseries/dataseries), an efficient, flexible data format for structured serial data. This modification to strace captures maximal information, including all data buffers and arguments. The output of fsl-strace is designed to be readable by both humans and machines, allowing researchers to use existing DataSeries tools to analyze trace files.
 
-This modification is designed for use with our [syscall-replayer](https://github.com/sbu-fsl/trace2model/tree/master/syscall-replayer), a program able to replay and analyze the system call traces collected in the DataSeries format. For more information on the Re-Animator project, please see our paper [Re-Animator: Versatile High-Fidelity Storage-System Tracing and Replaying](https://doi.org/10.1145/3383669.3398276).
+This modification is designed for use with our [syscall-replayer](https://github.com/SNIA/reanimator-library/tree/master/syscall-replayer), a program able to replay and analyze the system call traces collected in the DataSeries format. For more information on the Re-Animator project, please see our paper [Re-Animator: Versatile High-Fidelity Storage-System Tracing and Replaying](https://doi.org/10.1145/3383669.3398276).
 
 fsl-strace is under development by Ibrahim Umit Akgun of the File Systems and Storage Lab (FSL) at Stony Brook University under Professor Erez Zadok, with assistance from Professor Geoff Kuenning at Harvey Mudd College.
 
@@ -14,7 +14,7 @@ Currently, only Ubuntu 16 is officially supported.
 
 - [Lintel](https://github.com/dataseries/lintel) - general utility library for DataSeries
 - [DataSeries](https://github.com/dataseries/dataseries) - data format for structured serial data
-- [strace2ds-library](https://github.com/sbu-fsl/trace2model/tree/master/strace2ds-library) - library for outputting traces in DataSeries format
+- [strace2ds-library](https://github.com/SNIA/reanimator-library/tree/master/strace2ds-library) - library for outputting traces in DataSeries format
 - [tcmalloc](https://github.com/gperftools/gperftools) - high-performance, multi-threaded `malloc()` implementation
 - libtool
 - libboost-dev (v1.58 only)
@@ -60,7 +60,7 @@ Requires bash.
 
 4. Install [tcmalloc](https://github.com/gperftools/gperftools) from the gperftools repository. See the gperftools [`INSTALL`](https://github.com/gperftools/gperftools/blob/master/INSTALL) file for detailed instructions.
 
-5. Install [strace2ds-library](https://github.com/sbu-fsl/trace2model/tree/master/strace2ds-library). See the strace2ds-library [`README.md`](https://github.com/sbu-fsl/trace2model/blob/master/strace2ds-library/README.md) file for detailed instructions.
+5. Install [strace2ds-library](https://github.com/SNIA/reanimator-library/tree/master/strace2ds-library). See the strace2ds-library [`README.md`](https://github.com/SNIA/reanimator-library/blob/master/strace2ds-library/README.md) file for detailed instructions.
 
 6. In the fsl-strace repository, run the `./bootstrap` script as a wrapper to autotools.
 
@@ -89,7 +89,7 @@ To run the modified strace binary with DataSeries support, navigate to the build
 ./strace --dataseries output.ds <program to be traced>
 ```
 
-This will write all trace output in DataSeries format to `output.ds`. From there, you can read the output in plaintext with `ds2txt output.ds`, analyze the trace with any of the tools provided with DataSeries, or replay the trace with [syscall-replayer](https://github.com/sbu-fsl/trace2model/tree/master/syscall-replayer).
+This will write all trace output in DataSeries format to `output.ds`. From there, you can read the output in plaintext with `ds2txt output.ds`, analyze the trace with any of the tools provided with DataSeries, or replay the trace with [syscall-replayer](https://github.com/SNIA/reanimator-library/tree/master/syscall-replayer).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-fsl-strace - an strace fork compatible with DataSeries
+reanimator-strace - an strace fork compatible with DataSeries
 ======================================================
 
-fsl-strace extends strace with support for [DataSeries](https://github.com/dataseries/dataseries), an efficient, flexible data format for structured serial data. This modification to strace captures maximal information, including all data buffers and arguments. The output of fsl-strace is designed to be readable by both humans and machines, allowing researchers to use existing DataSeries tools to analyze trace files.
+reanimator-strace extends strace with support for [DataSeries](https://github.com/dataseries/dataseries), an efficient, flexible data format for structured serial data. This modification to strace captures maximal information, including all data buffers and arguments. The output of reanimator-strace is designed to be readable by both humans and machines, allowing researchers to use existing DataSeries tools to analyze trace files.
 
 This modification is designed for use with our [syscall-replayer](https://github.com/SNIA/reanimator-library/tree/master/syscall-replayer), a program able to replay and analyze the system call traces collected in the DataSeries format. For more information on the Re-Animator project, please see our paper [Re-Animator: Versatile High-Fidelity Storage-System Tracing and Replaying](https://doi.org/10.1145/3383669.3398276).
 
-fsl-strace is under development by Ibrahim Umit Akgun of the File Systems and Storage Lab (FSL) at Stony Brook University under Professor Erez Zadok, with assistance from Professor Geoff Kuenning at Harvey Mudd College.
+reanimator-strace is under development by Ibrahim Umit Akgun of the File Systems and Storage Lab (FSL) at Stony Brook University under Professor Erez Zadok, with assistance from Professor Geoff Kuenning at Harvey Mudd College.
 
 Dependencies
 ------------
@@ -39,10 +39,10 @@ Requires bash.
 
     On Ubuntu 16, all the above requirements are available through the APT package manager.
 
-2. Clone this repository and run [`build-fsl-strace.sh`](build-fsl-strace.sh). This will place build files in the current directory under `BUILD/` and install Lintel, DataSeries, tcmalloc, strace2ds-library, and fsl-strace under `dist/fsl_strace_release/`.
+2. Clone this repository and run [`build-reanimator-strace.sh`](build-reanimator-strace.sh). This will place build files in the current directory under `BUILD/` and install Lintel, DataSeries, tcmalloc, strace2ds-library, and reanimator-strace under `dist/reanimator_strace_release/`.
 
-    - The script will install include files and libraries under `/usr/local/` if invoked with `build-syscall-replayer.sh --install`. If installed this way, the fsl-strace binary will remain in the build folder so as not to conflict with the strace binary pre-installed on many systems.
-    - You may specify custom build and install directories with the command line options `--build-dir DIR` and `--install-dir DIR`. Run `./build-fsl-strace.sh --help` for a full list of options.
+    - The script will install include files and libraries under `/usr/local/` if invoked with `build-reanimator-strace.sh --install`. If installed this way, the reanimator-strace binary will remain in the build folder so as not to conflict with the strace binary pre-installed on many systems.
+    - You may specify custom build and install directories with the command line options `--build-dir DIR` and `--install-dir DIR`. Run `./build-reanimator-strace.sh --help` for a full list of options.
 
 ### Manual Build
 
@@ -62,7 +62,7 @@ Requires bash.
 
 5. Install [strace2ds-library](https://github.com/SNIA/reanimator-library/tree/master/strace2ds-library). See the strace2ds-library [`README.md`](https://github.com/SNIA/reanimator-library/blob/master/strace2ds-library/README.md) file for detailed instructions.
 
-6. In the fsl-strace repository, run the `./bootstrap` script as a wrapper to autotools.
+6. In the reanimator-strace repository, run the `./bootstrap` script as a wrapper to autotools.
 
 7. Create a directory named `BUILD` in the repository and navigate to it. Run the command
 

--- a/build-fsl-strace.sh
+++ b/build-fsl-strace.sh
@@ -145,7 +145,7 @@ runcmd cd "${repositoryDir}"
 [[ -d "Lintel" ]] || runcmd git clone https://github.com/dataseries/Lintel.git
 [[ -d "DataSeries" ]] || runcmd git clone https://github.com/dataseries/DataSeries.git
 [[ -d "gperftools" ]] || runcmd git clone https://github.com/gperftools/gperftools.git
-[[ -d "trace2model" ]] || runcmd git clone https://github.com/sbu-fsl/trace2model.git
+[[ -d "trace2model" ]] || runcmd git clone https://github.com/SNIA/reanimator-library.git
 
 # Building Lintel
 # ---------------

--- a/build-reanimator-strace.sh
+++ b/build-reanimator-strace.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Build the program fsl-strace, installing any required dependencies if
+# Build the program reanimator-strace, installing any required dependencies if
 # requested.
 
 ####################
@@ -10,7 +10,7 @@ readonly numberOfCores="$(nproc --all)"
 install=false
 installPackages=false
 configArgs=""
-installDir="$(pwd)/dist/fsl_strace_release"
+installDir="$(pwd)/dist/reanimator_strace_release"
 repositoryDir="$(pwd)/BUILD/repositories"
 straceDir="$(pwd)"
 
@@ -145,7 +145,7 @@ runcmd cd "${repositoryDir}"
 [[ -d "Lintel" ]] || runcmd git clone https://github.com/dataseries/Lintel.git
 [[ -d "DataSeries" ]] || runcmd git clone https://github.com/dataseries/DataSeries.git
 [[ -d "gperftools" ]] || runcmd git clone https://github.com/gperftools/gperftools.git
-[[ -d "trace2model" ]] || runcmd git clone https://github.com/SNIA/reanimator-library.git
+[[ -d "reanimator-library" ]] || runcmd git clone https://github.com/SNIA/reanimator-library.git
 
 # Building Lintel
 # ---------------
@@ -184,7 +184,7 @@ runcmd cd "${repositoryDir}"
 
 # Building strace2ds-library
 # --------------------------
-runcmd cd trace2model/strace2ds-library
+runcmd cd reanimator-library/strace2ds-library
 runcmd autoreconf -v -i
 runcmd rm -rf BUILD
 runcmd mkdir -p BUILD
@@ -207,7 +207,7 @@ else
 fi
 runcmd cd "${repositoryDir}"
 
-# Building fsl-strace
+# Building reanimator-strace
 # -------------------
 runcmd cd "${straceDir}"
 runcmd ./bootstrap

--- a/syscall.c
+++ b/syscall.c
@@ -1791,7 +1791,7 @@ syscall_exiting_trace(struct tcb *tcp, struct timespec *ts, int res)
 				break;
 			/*
 			 * These system calls are chosen not be traced by
-			 * fsl-strace.
+			 * reanimator-strace.
 			 */
 			case SEN_brk:
 			case SEN_mprotect:


### PR DESCRIPTION
Rename `trace2model` and `fsl` to `reanimator`